### PR TITLE
fix: Add ESC key support for closing modal - Closes #4

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -111,6 +111,12 @@ document.addEventListener('DOMContentLoaded', () => {
             closeModalFunc();
         }
     });
+// Close modal with ESC key for accessibility
+document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && modal.style.display === 'block') {
+        closeModalFunc();
+    }
+});
 
     // Search Functionality
     if (searchInput) {


### PR DESCRIPTION
## Description
Fixes Issue #8 - Modal can now be closed using the ESC key for better accessibility.

## Changes Made
- ✅ Added keydown event listener to document
- ✅ Modal closes when ESC key is pressed
- ✅ Only triggers when modal is visible
- ✅ Improves keyboard accessibility

## Testing
1. Open any recipe card to show modal
2. Press ESC key
3. Modal closes automatically ✅

## Before vs After
- **Before:** Modal only closed with mouse clicks
- **After:** Modal also closes with ESC key

## Related Issues
Closes #8 

## Type of Change
- [x] Bug fix (accessibility improvement)
- [x] Non-breaking change

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed  
- [x] Feature works as expected
- [x] Closes related issue