### PR TITLE
Disable external link checking in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         uses: anishathalye/proof-html@v2
         with:
           directory: .
+          # Disable external link checking - prevents network-dependent failures
+          disable-external: true
 
       - name: Check project structure
         run: |


### PR DESCRIPTION
Disable external link checking in HTML validation step to prevent network-dependent failures.